### PR TITLE
change quaternions update as original alphafold2

### DIFF
--- a/invariant_point_attention/invariant_point_attention.py
+++ b/invariant_point_attention/invariant_point_attention.py
@@ -320,7 +320,7 @@ class IPATransformer(nn.Module):
             quaternion_update, translation_update = to_update(x).chunk(2, dim = -1)
             quaternion_update = F.pad(quaternion_update, (1, 0), value = 1.)
 
-            quaternions = quaternions + quaternion_multiply(quaternions, quaternion_update)
+            quaternions = quaternion_multiply(quaternions, quaternion_update)
             translations = translations + einsum('b n c, b n c r -> b n r', translation_update, rotations)
 
         if not self.predict_points:


### PR DESCRIPTION
In the original alphafold2 IPA module, pure-quaternion (without real part) description is used for quaternion update. This can be broken down to the residual-update-like formulation.  But in this code you use (1, a, b, c) style quaternion so I believe the quaternion update should be done as a simple multiply update. As far as I have tested, the loss seems to go down more efficiently with the modification.